### PR TITLE
Fix lambda build docker login

### DIFF
--- a/lambda/buildspec.yml
+++ b/lambda/buildspec.yml
@@ -6,7 +6,7 @@ phases:
       - echo "Logging in to Amazon ECR..."
       - aws --version
       - echo "Using region $AWS_DEFAULT_REGION and account $AWS_ACCOUNT_ID"
-      - $(aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com)
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
       - COMMIT_SHA=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_URI=${AWS_ACCOUNT_ID}.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/${ECR_REPO}:$COMMIT_SHA
   build:


### PR DESCRIPTION
Fix CodeBuild failure by correcting the ECR login command syntax in `lambda/buildspec.yml`.

The previous command `$(aws ecr get-login-password ... | docker login ...)` used command substitution, which caused the shell to attempt to execute the *output* of the `docker login` command (e.g., "Login Succeeded") as a new command, resulting in the "Login: not found" error. Removing the `$(...)` wrapper ensures the password is correctly piped to `docker login`.